### PR TITLE
Minor change on the button component: Instead of manually typing the button type, use BUT…

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -8,7 +8,7 @@ import {
   Title,
   Text,
 } from "@mantine/core";
-
+import { BUTTON_VARIANTS } from "~/components/Button";
 import { Button } from "~/components";
 import { Container, Frame } from "../components";
 
@@ -45,7 +45,7 @@ const LogIn = () => {
           />
           <Checkbox label="Keep me logged in" mt="xl" size="md" />
 
-          <Button buttonType="secondary" style={{ marginTop: "5%" }}>
+          <Button buttonType={BUTTON_VARIANTS.SECONDARY} style={{ marginTop: "5%" }}>
             Login
           </Button>
 

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -9,6 +9,7 @@ import {
   Title,
 } from "@mantine/core";
 import { useForm } from "@mantine/form";
+import {BUTTON_VARIANTS} from "~/components/Button";
 import { Button } from "~/components";
 import { Container, Frame } from "../components";
 import { useStyles } from "../style";
@@ -71,7 +72,7 @@ const Signup = () => {
                 placeholder="Confirm password"
                 {...form.getInputProps("confirmPassword")}
               />
-              <Button buttonType="primary" type="submit" mt="sm">
+              <Button buttonType={BUTTON_VARIANTS.PRIMARY} type="submit" mt="sm">
                 Submit
               </Button>
 


### PR DESCRIPTION

### Feature Description

Made a change based on the feedback from Yuko.
[https://github.com/van-squad/map-t3/pull/23#discussion_r1252489451](https://github.com/van-squad/map-t3/pull/23#discussion_r1252489451)

Initially, I was going to follow Joy's suggestion and rename the property from 'buttonType' to 'type.' However, I noticed that Mantine forms already use 'type,' so I think sticking with 'buttonType' is a better choice.

[https://github.com/van-squad/map-t3/pull/23#issuecomment-1624359797](https://github.com/van-squad/map-t3/pull/23#issuecomment-1624359797)
![Screenshot 2023-07-20 at 1 22 04 PM](https://github.com/van-squad/map-t3/assets/70562492/10551800-21e6-4287-900f-5e39205c129d)



### Related Issue

[#23 ](https://github.com/van-squad/map-t3/pull/23)

### Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
