### PR TITLE
Add two buttons: one for in-person events and another for both in-person and online events. Display the number of events on the selected date.

### DIFF
--- a/src/app/map/components/GoogleMaps/index.tsx
+++ b/src/app/map/components/GoogleMaps/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
-import { useMantineColorScheme, Image, Text } from "@mantine/core";
+import { useMantineColorScheme, Image, Text, Paper } from "@mantine/core";
 import { mapTheme, loader } from "~/utils";
 import Calendar from "../Calendar";
 import EventCard from "../EventCard";
@@ -96,37 +96,55 @@ export const GoogleMaps = ({ setMapLoaded }: GoogleMapsProps) => {
       void fetchMap();
     }
   }, [colorScheme, setMapLoaded, loading, error, result]);
-
+ 
+const [totalEvents, setTotalEvents] = useState(0);
   useEffect(() => {
-    if (!loading && !error && result && result.length > 0) {
-      const markerElements = result.map((event) => {
-        return (
-          event?.venue?.lat &&
-          event?.venue?.lng && (
-            <Marker
-              key={event.id}
-              position={{
-                lat: event.venue.lat,
-                lng: event.venue.lng,
-              }}
-              onClick={() => {
-                setInfoWindowID(event.id);
-              }}
-              icon={{ url: "/images/marker.svg" }}
-            >
-              {infoWindowID === event.id && (
-                <InfoWindow onCloseClick={() => setInfoWindowID(null)}>
-                  <EventCard event={event} />
-                </InfoWindow>
-              )}
-            </Marker>
-          )
-        );
-      });
-      setMarkers(markerElements as JSX.Element[]);
+    if (!loading && !error && result) {
+      if (result.length > 0) {
+        setNoEvents(false);
+        setEvents(true);
+        setTotalEvents(result.length);
+
+        const markerElements = result.map((event) => {
+          return (
+            event?.venue?.lat &&
+            event?.venue?.lng && (
+              <Marker
+                key={event.id}
+                position={{
+                  lat: event.venue.lat,
+                  lng: event.venue.lng,
+                }}
+                onClick={() => {
+                  setInfoWindowID(event.id);
+                }}
+                icon={{ url: "/images/marker.svg" }}
+              >
+                {infoWindowID === event.id && (
+                  <InfoWindow onCloseClick={() => setInfoWindowID(null)}>
+                    <EventCard event={event} />
+                  </InfoWindow>
+                )}
+              </Marker>
+            )
+          );
+        });
+        setMarkers(markerElements as JSX.Element[]);
+      }else{
+setEvents(false);
+setNoEvents(true);
+      }
     }
+   
   }, [loading, error, result, infoWindowID]);
 
+
+ const [noEvents, setNoEvents] = useState(false);
+ const [events, setEvents] = useState(false);
+
+ const toggleCard = () => {
+   setNoEvents(false);
+ };
 
   return (
     <div>
@@ -147,6 +165,22 @@ export const GoogleMaps = ({ setMapLoaded }: GoogleMapsProps) => {
           {markers}
         </GoogleMap>
       </LoadScript>
+
+      {noEvents && !loading ? (
+        <div className={classes.overlay} onClick={toggleCard}>
+          <Paper shadow="xs" p="xl" className={classes.popup}>
+            <Text>There are no events on {date?.toDateString()}</Text>
+          </Paper>
+        </div>
+      ) : events && !loading ? (
+        <Paper shadow="xs" p="xl" className={classes.eventsPopup}>
+          <Text>
+            {totalEvents === 1
+              ? `There is 1 tech event!`
+              : `There are ${totalEvents} tech events!`}
+          </Text>
+        </Paper>
+      ) : null}
 
       <div className={classes.container}>
         <Calendar date={date} setDate={setDate} />

--- a/src/app/map/components/GoogleMaps/index.tsx
+++ b/src/app/map/components/GoogleMaps/index.tsx
@@ -96,8 +96,8 @@ export const GoogleMaps = ({ setMapLoaded }: GoogleMapsProps) => {
       void fetchMap();
     }
   }, [colorScheme, setMapLoaded, loading, error, result]);
- 
-const [totalEvents, setTotalEvents] = useState(0);
+
+  const [totalEvents, setTotalEvents] = useState(0);
   useEffect(() => {
     if (!loading && !error && result) {
       if (result.length > 0) {
@@ -130,21 +130,19 @@ const [totalEvents, setTotalEvents] = useState(0);
           );
         });
         setMarkers(markerElements as JSX.Element[]);
-      }else{
-setEvents(false);
-setNoEvents(true);
+      } else {
+        setEvents(false);
+        setNoEvents(true);
       }
     }
-   
   }, [loading, error, result, infoWindowID]);
 
+  const [noEvents, setNoEvents] = useState(false);
+  const [events, setEvents] = useState(false);
 
- const [noEvents, setNoEvents] = useState(false);
- const [events, setEvents] = useState(false);
-
- const toggleCard = () => {
-   setNoEvents(false);
- };
+  const toggleCard = () => {
+    setNoEvents(false);
+  };
 
   return (
     <div>

--- a/src/app/map/components/GoogleMaps/styles.ts
+++ b/src/app/map/components/GoogleMaps/styles.ts
@@ -20,8 +20,8 @@ export const useStyles = createStyles((theme) => ({
   },
   container: {
     position: "absolute",
-    top: "10px",
-    left: "10px",
+    top: "80px",
+    left: "20px",
     zIndex: 20,
     backgroundColor:
       theme.colorScheme === "dark" ? theme.colors.blue[3] : theme.white,
@@ -51,5 +51,29 @@ export const useStyles = createStyles((theme) => ({
     alignItems: "center",
     flexDirection: "column",
     padding: "2rem 3rem",
+  },
+  overlay: {
+    position: "fixed",
+    top: "0",
+    left: "0",
+    width: "100vw",
+    height: "100vh",
+    backgroundColor: "rgba(0,0,0,0.5)",
+  },
+  popup: {
+    position: "absolute",
+    top: "50%",
+    left: "50%",
+    transform: "translate(-50%,-50%)",
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+    flexDirection: "column",
+    padding: "2rem 3rem",
+  },
+  eventsPopup: {
+    position: "absolute",
+    top: "50%",
+    left: "3%",
   },
 }));

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 import Image from "next/image";
 import { Text } from "@mantine/core";
 import { Button } from "~/app/components";
+import { BUTTON_VARIANTS } from "~/app/components/Button";
 import { useStyles } from "./styles";
 
 const HomePage = () => {
@@ -34,7 +35,21 @@ const HomePage = () => {
                 happening in Vancouver? This app displays all upcoming tech
                 events in Vancouver, and you can search for events by date.
               </Text>
-              <Button name="Find Events" href="/map" buttonType="tertiary" />
+              <Text fw={500} mb={20} maw={380} ta="center">
+                Are you looking for
+              </Text>
+              <div className={classes.buttons}>
+                <Button
+                  name="In-person Events"
+                  href="/map"
+                  buttonType={BUTTON_VARIANTS.TERTIARY}
+                />
+                <Button
+                  name="In-person & Online Events"
+                  href="#"
+                  buttonType={BUTTON_VARIANTS.PRIMARY}
+                />
+              </div>
             </div>
           </div>
         </div>

--- a/src/app/styles.ts
+++ b/src/app/styles.ts
@@ -58,6 +58,7 @@ export const useStyles = createStyles((theme) => ({
     transform: "rotate(1deg)",
   },
   flexContainer: {
+    paddingTop: "2%",
     display: "flex",
     height: "100%",
     flexDirection: "column",
@@ -76,5 +77,20 @@ export const useStyles = createStyles((theme) => ({
     marginBottom: rem(20),
     maxWidth: rem(380),
     textAlign: "center",
+  },
+  buttons: {
+    display: "flex",
+    flexDirection: "row",
+    button: {
+      margin: "0  0.5rem",
+      width: rem(220),
+      height: rem(50),
+      [`@media (max-width: 768px)`]: {
+        margin: "0.3rem 0",
+      },
+    },
+    [`@media (max-width: 768px)`]: {
+      flexDirection: "column",
+    },
   },
 }));


### PR DESCRIPTION
### Feature Description

Two buttons on the home page. One is directed to the map page and another one will be directed to the list view page. 
<img width="1084" alt="Screenshot 2023-10-13 at 5 58 55 PM" src="https://github.com/van-squad/map-t3/assets/70562492/5a1f496a-e77d-406a-a58d-092de8f974b4">

Also, I implemented a popup message that shows the number of events on the selected date. I thought it will enhance user experience. 

![giphy](https://github.com/van-squad/map-t3/assets/70562492/93fc356a-f7ef-42ae-ac97-8010c2a8182e)


### Related Issue

close #67 


### Something you want to mention

From 'no events' to 'events' doesn't have smooth transition as you can see in the video. I need to look into it.


### Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
