### PR TITLE
enhanced search results

### DIFF
--- a/src/app/api/events/all/route.ts
+++ b/src/app/api/events/all/route.ts
@@ -49,7 +49,7 @@ export type ModifiedResult = Omit<Result, "dateTime" | "image"> & {
 };
 
 const FILTER_CONSTANT = {
-  query: "tech",
+  query: "VanJS, Tech, CodeWeekend, 'Tech Nerds', 'ReactJS'",
   // These point at Vancouver
   lat: 49.246292,
   lon: -123.116226,
@@ -67,13 +67,9 @@ export async function POST(req: Request) {
 
     const vancouverTime = moment.tz(dateObject, "America/Vancouver");
 
-    // Get the day of 0:00
-    const startOfDay = vancouverTime.clone().startOf("day");
-    const startOfDayString = startOfDay.format("YYYY-MM-DDTHH:mm:ss.SSS[Z]");
-
-    // Get the day of 23:59:59
-    const endOfDay = vancouverTime.clone().endOf("day");
-    const endOfDayString = endOfDay.format("YYYY-MM-DDTHH:mm:ss.SSS[Z]");
+    const startOfDayString = vancouverTime.format();
+    vancouverTime.endOf("day");
+    const endOfDayString = vancouverTime.format();
     const variables = {
       filter: {
         ...FILTER_CONSTANT,


### PR DESCRIPTION
### Feature Description

Included some tech event groups names in the query. Now there are more tech related events displayed including VanJs and React Vancouver.
We can keep working on better query.

### Related Issue

close #60

<!--- Put issue number if it's related. ex) #8 -->
<!--- Delete it if not needed -->

### Something you want to mention

For some reason, events that are listed is one day off. For example, when I search events on October 19, I see events that are on the 18th.

<img width="912" alt="Screenshot 2023-10-17 at 8 15 04 PM" src="https://github.com/van-squad/map-t3/assets/70562492/ae3ad4f4-ee16-411b-92f4-34c0036f46e2">

Seems like I fixed the issue but not really sure why the code we had didn't work haha .

Issues with search results that we need to work on...

1. There are some events in the United States
2. There are some events that are the same location but on the map I only see one event.

Example is this below
Brain station has three events on the same day at the same time

<img width="843" alt="Screenshot 2023-10-17 at 8 17 13 PM" src="https://github.com/van-squad/map-t3/assets/70562492/ab9d679a-ec3d-44f2-96e5-13f0fe4c5a0a">

<img width="757" alt="Screenshot 2023-10-17 at 8 18 34 PM" src="https://github.com/van-squad/map-t3/assets/70562492/ea0f7ae5-3207-48de-9b75-f015961e77f0">

Maybe it might be better to list events somewhere so it's easy to see look through events... ?

### Checklist before requesting a review

- [x]  My code follows the style guidelines of this project
- [x]  I have performed a self-review of my code
- [x]  I have commented my code, particularly in hard-to-understand areas
- [x]  My changes generate no new warnings