### PR TITLE
Stop showing header links when session status is loading

### DIFF
--- a/src/app/components/Header/index.tsx
+++ b/src/app/components/Header/index.tsx
@@ -49,7 +49,7 @@ const LINKS = [
 
 const Header = () => {
   const activePathname = usePathname();
-  const { data: session } = useSession();
+  const { data: session, status } = useSession();
   const [opened, { toggle }] = useDisclosure(false);
   const { classes, cx } = useStyles();
   const navLinks = session
@@ -87,7 +87,7 @@ const Header = () => {
 
         <div style={{ display: "flex", alignItems: "center" }}>
           <Group spacing={5} className={classes.links}>
-            {items}
+            {status !== "loading" && items}
           </Group>
           <ThemeSwitch />
           <Burger
@@ -101,7 +101,7 @@ const Header = () => {
         <Transition transition="pop-top-right" duration={200} mounted={opened}>
           {(styles) => (
             <Paper className={classes.dropdown} style={styles} onClick={toggle}>
-              {items}
+              {status !== "loading" && items}
             </Paper>
           )}
         </Transition>

--- a/src/server/api/context.ts
+++ b/src/server/api/context.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import type * as trpc from "@trpc/server";
 import type * as trpcNext from "@trpc/server/adapters/next";
-import { getServerSession } from "next-auth";
+import { getServerSession, type Session } from "next-auth";
 import type { getUser, User } from "~/server-rsc/getUser";
 import { authOptions } from "~/server/auth";
 
@@ -9,6 +9,7 @@ import { authOptions } from "~/server/auth";
 interface CreateContextOptions {
   user: User | null;
   rsc: boolean;
+  session: Session;
 }
 
 /**
@@ -18,6 +19,7 @@ interface CreateContextOptions {
 export function createContextInner(opts: CreateContextOptions) {
   return {
     user: opts.user,
+    session: opts.session,
   };
 }
 

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -1,4 +1,3 @@
-import { type GetServerSidePropsContext } from "next";
 import {
   getServerSession,
   type DefaultSession,
@@ -24,11 +23,6 @@ declare module "next-auth" {
       // role: UserRole;
     } & DefaultSession["user"];
   }
-
-  // interface User {
-  //   // ...other properties
-  //   // role: UserRole;
-  // }
 }
 
 /**
@@ -76,22 +70,17 @@ export const authOptions: NextAuthOptions = {
       return token;
     },
     session({ session, token }) {
-      // session.expires = 15 * 60 * 60
-      const updatedSession = {
-        ...session,
-        accessToken: token.accessToken,
-      };
-      updatedSession.user.id = token.sub as string;
-      return updatedSession;
+      session.user.id = token.sub as string;
+      return session;
     },
   },
-  jwt: {
-    maxAge: 60 * 60 * 24 * 90,
-  },
   session: {
-    // strategy: "jwt",
+    strategy: "jwt",
     maxAge: 60 * 60 * 24 * 90,
     updateAge: 15 * 60,
+  },
+  jwt: {
+    maxAge: 30 * 24 * 60 * 60,
   },
 };
 
@@ -100,9 +89,4 @@ export const authOptions: NextAuthOptions = {
  *
  * @see https://next-auth.js.org/configuration/nextjs
  */
-export const getServerAuthSession = (ctx: {
-  req: GetServerSidePropsContext["req"];
-  res: GetServerSidePropsContext["res"];
-}) => {
-  return getServerSession(ctx.req, ctx.res, authOptions);
-};
+export const getServerAuthSession = () => getServerSession(authOptions);

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -3,7 +3,7 @@ import {
   type DefaultSession,
   type NextAuthOptions,
 } from "next-auth";
-
+import type { GetServerSidePropsContext } from "next";
 import CredentialsProvider from "next-auth/providers/credentials";
 import { prisma } from "~/server/db";
 import { verifyPassword } from "~/utils";
@@ -89,4 +89,7 @@ export const authOptions: NextAuthOptions = {
  *
  * @see https://next-auth.js.org/configuration/nextjs
  */
-export const getServerAuthSession = () => getServerSession(authOptions);
+export const getServerAuthSession = (ctx: {
+  req: GetServerSidePropsContext["req"];
+  res: GetServerSidePropsContext["res"];
+}) => getServerSession(ctx.req, ctx.res, authOptions);


### PR DESCRIPTION
### Feature Description

<!--- Describe your changes in detail -->
- Added `status` of `session` in Header component so that links in Header are not shown until `session` is confirmed.
- Cleaned up codes of `src/server/auth.ts`

https://github.com/van-squad/map-t3/assets/65790344/6c2e92dc-1479-4216-a57c-78f38b04ab8d



### Related Issue

<!--- Put issue number if it's related. ex) #8 -->
<!--- Delete it if not needed -->
- close #90 

### Something you want to mention

<!--- Make a note about some problems or questions -->
<!--- Delete it if not needed -->
- Still we remain the issue of toggling background-color (When theme is `dark`, we want to show dark background-color from the beginning)

### Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
