### PR TITLE
Display favEvents in the order of timeline

### DIFF
--- a/src/app/favlist/page.tsx
+++ b/src/app/favlist/page.tsx
@@ -18,9 +18,12 @@ const FavPage = () => {
     userId,
   });
 
-  const eventIds = favEvents.data?.map((event) => {
-    return event.id;
-  });
+  const eventIds = favEvents.data
+    // sort favEvents in the order of timeline
+    ?.sort((a, b) => (a.date > b.date ? 1 : -1))
+    .map((event) => {
+      return event.id;
+    });
 
   useEffect(() => {
     if (!session) redirect("/login");

--- a/src/app/favlist/page.tsx
+++ b/src/app/favlist/page.tsx
@@ -18,12 +18,9 @@ const FavPage = () => {
     userId,
   });
 
-  const eventIds = favEvents.data
-    // sort favEvents in the order of timeline
-    ?.sort((a, b) => (a.date > b.date ? 1 : -1))
-    .map((event) => {
-      return event.id;
-    });
+  const eventIds = favEvents.data?.map((event) => {
+    return event.id;
+  });
 
   useEffect(() => {
     if (!session) redirect("/login");

--- a/src/server/api/routers/favoriteEvent.ts
+++ b/src/server/api/routers/favoriteEvent.ts
@@ -13,6 +13,11 @@ export const favoriteEventsRouter = router({
     )
     .query(async ({ input }) => {
       const favEvents = await prisma.favEvent.findMany({
+        orderBy: [
+          {
+            date: "asc",
+          },
+        ],
         where: { userId: input.userId },
       });
       if (!favEvents) {


### PR DESCRIPTION
### Feature Description

<!--- Describe your changes in detail -->

- Modified the order of favEvents in order to display favEvents in the order of timeline

https://github.com/van-squad/map-t3/assets/65790344/47583acd-d64f-41fd-8407-42f2def9cb05



### Related Issue

<!--- Put issue number if it's related. ex) #8 -->
<!--- Delete it if not needed -->
- close #88 

### Something you want to mention

<!--- Make a note about some problems or questions -->
<!--- Delete it if not needed -->

### Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
