### PR TITLE
Replaced publicProcedure to privateProcedure

### DIFF
--- a/src/server/api/routers/favoriteEvent.ts
+++ b/src/server/api/routers/favoriteEvent.ts
@@ -1,10 +1,10 @@
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { prisma } from "~/server/db";
-import { router, publicProcedure } from "../trpc";
+import { router, privateProcedure } from "../trpc";
 
 export const favoriteEventsRouter = router({
-  getFavorites: publicProcedure
+  getFavorites: privateProcedure
     .input(
       z.object({
         // userId
@@ -23,7 +23,7 @@ export const favoriteEventsRouter = router({
       }
       return favEvents;
     }),
-  addFavorite: publicProcedure
+  addFavorite: privateProcedure
     .input(
       z.object({
         // meetup data
@@ -40,7 +40,7 @@ export const favoriteEventsRouter = router({
         },
       });
     }),
-  deleteFavorite: publicProcedure
+  deleteFavorite: privateProcedure
     .input(
       z.object({
         // meetup data, userId?


### PR DESCRIPTION
### Feature Description

<!--- Describe your changes in detail -->
- Added `privateProcedure` instead of `publicProcedure` to functions in `src/server/api/routers/favoriteEvent.ts`

https://github.com/van-squad/map-t3/assets/65790344/d0c02508-29d2-489c-bf5c-549a3fb135c4



### Related Issue

<!--- Put issue number if it's related. ex) #8 -->
<!--- Delete it if not needed -->
- close #73 

### Something you want to mention

<!--- Make a note about some problems or questions -->
<!--- Delete it if not needed -->
- After adding `NEXTAUTH_SECRET` correctly, `privateProcedure` works fine without any other code changes (`NEXTAUTH_SECRET` is sooooo important 🤣 ）

### Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
